### PR TITLE
Update requirements.txt to include pillow rather than PIL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pywt
 scipy
 scikit-image
 tqdm
-PIL
+pillow


### PR DESCRIPTION
Pillow is a fork of PIL that is updated regularly (https://pillow.readthedocs.io/en/5.1.x/about.html#what-about-pil). PIL recently added support for Python 3, but it's not really being actively developed.